### PR TITLE
Working builds, README and gitignore.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             slackSend(message: 'Build completed', color: 'good')
         }
         failure {
-            slackSend(message: 'Build completed', color: 'danger')
+            slackSend(message: 'Build failed', color: 'danger')
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
             parallel {
                 stage('Verify Amazon Linux') { steps { script {verify_image('amazonlinux.json')}}}
                 stage('Verify Amazon Linux 2') { steps { script {verify_image('amazonlinux2.json')}}}
-                stage('Verify Amazon Linux 2 Jenkins Slave') { steps { script {verify_image('amazonlinux2jenkins_slave.json')}}}
+                stage('Verify Amazon Linux 2 Jenkins Slave') { steps { script {verify_image('jenkins_slave.json')}}}
                // stage('Verify Centos 7') { steps { script {verify_image('centos7.json')}}}
                // stage('Verify Oracle Linux') { steps { script {verify_image('oraclelinux.json')}}}
             }
@@ -38,7 +38,7 @@ pipeline {
             parallel {
                 stage('Build Amazon Linux') { steps { script {build_image('amazonlinux.json')}}}
                 stage('Build Amazon Linux 2') { steps { script {build_image('amazonlinux2.json')}}}
-                stage('Build Amazon Linux 2 Jenkins Slave') { steps { script {build_image('amazonlinux2jenkins_slave.json')}}}
+                stage('Build Amazon Linux 2 Jenkins Slave') { steps { script {build_image('jenkins_slave.json')}}}
                 //stage('Build Centos 7') { steps { script {build_image('centos7.json')}}}
                 //stage('Build Oracle Linux') { steps { script {build_image('oraclelinux.json')}}}
             }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Packer images
+
+## How to use
+
+The base images for Amazon Linux and Amazon Linux 2 are publically available.
+
+To use them you can search for the names listed in the build and use the account alias 'hmpps-engineering'
+
+An example for using the base images is in the jenkins_slave.json builder
+
+## Images
+
+* Amazon Linux (amazonlinux.json)
+* Amazon Linux 2 (amazonlinux2.json)
+* CentOS 7 (centos7.json)
+* Oracle Linux (oraclelinux.json)

--- a/amazonlinux.json
+++ b/amazonlinux.json
@@ -30,6 +30,7 @@
       "instance_type": "t2.micro",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "ec2-user",
+      "ami_groups": "all",
       "ami_name": "HMPPS Base Amazon Linux {{timestamp}}"
     }
   ]

--- a/amazonlinux2.json
+++ b/amazonlinux2.json
@@ -30,6 +30,7 @@
       "instance_type": "t2.micro",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "ec2-user",
+      "ami_groups": "all",
       "ami_name": "HMPPS Base Amazon Linux 2 LTS {{timestamp}}"
     }
   ]

--- a/amazonlinux2.json
+++ b/amazonlinux2.json
@@ -11,7 +11,7 @@
       "type": "ansible",
       "playbook_file": "./ansible/amazonlinux.yml",
       "extra_arguments": [ "-b" ],
-      "groups": ["amazonlinux2"],
+      "groups": ["amazonlinux2"]
     }
   ],
   "builders": [

--- a/amazonlinux2.json
+++ b/amazonlinux2.json
@@ -10,7 +10,8 @@
     {
       "type": "ansible",
       "playbook_file": "./ansible/amazonlinux.yml",
-      "extra_arguments": [ "-b" ]
+      "extra_arguments": [ "-b" ],
+      "groups": ["amazonlinux2"],
     }
   ],
   "builders": [

--- a/ansible/amazonlinux.yml
+++ b/ansible/amazonlinux.yml
@@ -1,4 +1,4 @@
 - hosts: default
   roles:
     - dev-sec.os-hardening
-    - linuxhq.yum-cron
+    - linuxhq.yum_cron

--- a/ansible/centos7.yml
+++ b/ansible/centos7.yml
@@ -1,4 +1,4 @@
 - hosts: default
   roles:
     - dev-sec.os-hardening
-    - linuxhq.yum-cron
+    - linuxhq.yum_cron

--- a/ansible/group_vars/amazonlinux2
+++ b/ansible/group_vars/amazonlinux2
@@ -1,0 +1,1 @@
+os_auth_pam_passwdqc_enable: false

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,2 +1,2 @@
 - src: dev-sec.os-hardening
-- src: linuxhq.yum-cron
+- src: linuxhq.yum_cron

--- a/jenkins_slave.json
+++ b/jenkins_slave.json
@@ -10,16 +10,7 @@
     },
     {
       "type": "shell",
-      "script": "scripts/update.sh"
-    },
-    {
-      "type": "shell",
       "script": "scripts/jenkins_slave.sh"
-    },
-    {
-      "type": "ansible",
-      "playbook_file": "./ansible/amazonlinux.yml",
-      "extra_arguments": [ "-b" ]
     }
   ],
   "builders": [
@@ -30,10 +21,10 @@
         "filters": {
           "virtualization-type": "hvm",
           "architecture": "x86_64",
-          "description": "Amazon Linux 2 LTS*",
+          "description": "HMPPS Base Amazon Linux 2 LTS*",
           "root-device-type": "ebs"
         },
-        "owners": ["amazon"],
+        "owners": ["hmpps-engineering"],
         "most_recent": true
       },
       "instance_type": "t2.micro",

--- a/jenkins_slave.json
+++ b/jenkins_slave.json
@@ -24,7 +24,7 @@
           "description": "HMPPS Base Amazon Linux 2 LTS*",
           "root-device-type": "ebs"
         },
-        "owners": ["hmpps-engineering-non-prod"],
+        "owners": ["895523100917"],
         "most_recent": true
       },
       "instance_type": "t2.micro",

--- a/jenkins_slave.json
+++ b/jenkins_slave.json
@@ -21,7 +21,7 @@
         "filters": {
           "virtualization-type": "hvm",
           "architecture": "x86_64",
-          "description": "HMPPS Base Amazon Linux 2 LTS*",
+          "name": "HMPPS Base Amazon Linux 2 LTS*",
           "root-device-type": "ebs"
         },
         "owners": ["895523100917"],

--- a/jenkins_slave.json
+++ b/jenkins_slave.json
@@ -24,7 +24,7 @@
           "description": "HMPPS Base Amazon Linux 2 LTS*",
           "root-device-type": "ebs"
         },
-        "owners": ["hmpps-engineering"],
+        "owners": ["hmpps-engineering-non-prod"],
         "most_recent": true
       },
       "instance_type": "t2.micro",

--- a/scripts/jenkins_slave.sh
+++ b/scripts/jenkins_slave.sh
@@ -26,6 +26,7 @@ sudo make install PREFIX=/usr/local
 cd /tmp
 rm -rf *0.6.0*
 
+sudo systemctl -w vm.max_map_count=262144
 sudo systemctl start docker
 
 sudo pip install virtualenv awscli

--- a/scripts/jenkins_slave.sh
+++ b/scripts/jenkins_slave.sh
@@ -26,7 +26,7 @@ sudo make install PREFIX=/usr/local
 cd /tmp
 rm -rf *0.6.0*
 
-sudo systemctl -w vm.max_map_count=262144
+echo "vm.max_map_count=262144" |  sudo tee -a /etc/sysctl.conf
 sudo systemctl start docker
 
 sudo pip install virtualenv awscli

--- a/scripts/jenkins_slave.sh
+++ b/scripts/jenkins_slave.sh
@@ -4,8 +4,7 @@ set -e
 
 sudo cp /usr/share/zoneinfo/Europe/London /etc/localtime
 
-sudo yum install -y docker \
-     yum-utils \
+sudo yum install -y yum-utils \
      device-mapper-persistent-data \
      lvm2 \
      gcc \
@@ -16,6 +15,8 @@ sudo yum install -y docker \
      java-1.8.0-openjdk \
      python-pip \
      jq
+
+sudo amazon-linux-extras install -y docker
 
 cd /tmp
 wget https://github.com/AGWA/git-crypt/archive/0.6.0.tar.gz
@@ -29,11 +30,14 @@ rm -rf *0.6.0*
 echo "vm.max_map_count=262144" |  sudo tee -a /etc/sysctl.conf
 sudo systemctl start docker
 
+sudo curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
 sudo pip install virtualenv awscli
 sudo curl -fsSL https://goss.rocks/install | sudo sh
 
 sudo usermod -aG docker ec2-user
 
-chmod +x /home/ec2-user/configure_github
+sudo chmod +x /home/ec2-user/configure_github
 
 


### PR DESCRIPTION
Adding a basic README that explains the repo.

Moving the Jenkins slave to build on top of the Amazon Linux 2 image we build which should shorten the build times for the Jenkins slave AMI.