### PR TITLE
Publish the CentOS 7 image.

### DIFF
--- a/centos7.json
+++ b/centos7.json
@@ -30,6 +30,7 @@
       "instance_type": "t2.micro",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
+      "ami_groups": "all",
       "ami_name": "HMPPS Base CentOS {{timestamp}}"
     }
   ]


### PR DESCRIPTION
Make the CentOS 7 image available to all.

Without this the CentOS can't be used in other accounts.