### PR TITLE
Passing the branch name to the build container.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ def verify_image(filename) {
     wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
         sh '''
         #!/usr/env/bin bash
-        docker run --rm -v `pwd`:/home/tools/data mojdigitalstudio/hmpps-packer-builder bash -c 'USER=`whoami` packer validate ''' + filename + "'"
+        docker run --rm -e BRANCH_NAME -v `pwd`:/home/tools/data mojdigitalstudio/hmpps-packer-builder bash -c 'USER=`whoami` packer validate ''' + filename + "'"
     }
 }
 
@@ -10,7 +10,7 @@ def build_image(filename) {
     wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
         sh '''
         #!/usr/env/bin bash
-        docker run --rm -v `pwd`:/home/tools/data mojdigitalstudio/hmpps-packer-builder bash -c 'ansible-galaxy install -r ansible/requirements.yml; USER=`whoami` packer build ''' + filename + "'"
+        docker run --rm -e BRANCH_NAME -v `pwd`:/home/tools/data mojdigitalstudio/hmpps-packer-builder bash -c 'ansible-galaxy install -r ansible/requirements.yml; USER=`whoami` packer build ''' + filename + "'"
     }
 }
 


### PR DESCRIPTION
Docker in docker in docker.

The environment var from the build needs to be passed into the
packer container to allow packer to use this in the container name.

Build shows branch name in the linked build below.

https://jenkins.engineering-dev.probation.hmpps.dsd.io/job/ops/job/HMPPS_PACKER_BUILDER/job/pass_branch_name/1/console