### PR TITLE
Feature/fix sec alerts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
 
         stage('Build Alfresco AMIS') {
             parallel {
-                stage('Build Centos Alfresco') { steps { script {build_image('alfresco.json')}}}
+                //stage('Build Centos Alfresco') { steps { script {build_image('alfresco.json')}}}
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,20 +38,20 @@ pipeline {
 
         stage('Verify Packer AMIS') {
             parallel {
-                stage('Verify Amazon Linux') { steps { script {verify_image('amazonlinux.json')}}}
-                stage('Verify Amazon Linux 2') { steps { script {verify_image('amazonlinux2.json')}}}
-                stage('Verify Amazon Linux 2 Jenkins Slave') { steps { script {verify_image('jenkins_slave.json')}}}
+                //stage('Verify Amazon Linux') { steps { script {verify_image('amazonlinux.json')}}}
+                //stage('Verify Amazon Linux 2') { steps { script {verify_image('amazonlinux2.json')}}}
+                //stage('Verify Amazon Linux 2 Jenkins Slave') { steps { script {verify_image('jenkins_slave.json')}}}
                 stage('Verify Centos 7') { steps { script {verify_image('centos7.json')}}}
-                stage('Verify Centos Alfresco') { steps { script {verify_image('alfresco.json')}}}
+                //stage('Verify Centos Alfresco') { steps { script {verify_image('alfresco.json')}}}
                // stage('Verify Oracle Linux') { steps { script {verify_image('oraclelinux.json')}}}
             }
         }
 
         stage('Build Packer AMIS') {
             parallel {
-                stage('Build Amazon Linux') { steps { script {build_image('amazonlinux.json')}}}
-                stage('Build Amazon Linux 2') { steps { script {build_image('amazonlinux2.json')}}}
-                stage('Build Amazon Linux 2 Jenkins Slave') { steps { script {build_image('jenkins_slave.json')}}}
+                //stage('Build Amazon Linux') { steps { script {build_image('amazonlinux.json')}}}
+                //stage('Build Amazon Linux 2') { steps { script {build_image('amazonlinux2.json')}}}
+                //stage('Build Amazon Linux 2 Jenkins Slave') { steps { script {build_image('jenkins_slave.json')}}}
                 stage('Build Centos 7') { steps { script {build_image('centos7.json')}}}
                 //stage('Build Oracle Linux') { steps { script {build_image('oraclelinux.json')}}}
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,11 +57,11 @@ pipeline {
             }
         }
 
-        stage('Build Alfresco AMIS') {
-            parallel {
-                stage('Build Centos Alfresco') { steps { script {build_image('alfresco.json')}}}
-            }
-        }
+        //stage('Build Alfresco AMIS') {
+        //    parallel {
+        //        stage('Build Centos Alfresco') { steps { script {build_image('alfresco.json')}}}
+        //    }
+        //}
     }
 
     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
 
         stage('Build Alfresco AMIS') {
             parallel {
-                //stage('Build Centos Alfresco') { steps { script {build_image('alfresco.json')}}}
+                stage('Build Centos Alfresco') { steps { script {build_image('alfresco.json')}}}
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,20 +38,20 @@ pipeline {
 
         stage('Verify Packer AMIS') {
             parallel {
-                //stage('Verify Amazon Linux') { steps { script {verify_image('amazonlinux.json')}}}
-                //stage('Verify Amazon Linux 2') { steps { script {verify_image('amazonlinux2.json')}}}
-                //stage('Verify Amazon Linux 2 Jenkins Slave') { steps { script {verify_image('jenkins_slave.json')}}}
+                stage('Verify Amazon Linux') { steps { script {verify_image('amazonlinux.json')}}}
+                stage('Verify Amazon Linux 2') { steps { script {verify_image('amazonlinux2.json')}}}
+                stage('Verify Amazon Linux 2 Jenkins Slave') { steps { script {verify_image('jenkins_slave.json')}}}
                 stage('Verify Centos 7') { steps { script {verify_image('centos7.json')}}}
-                //stage('Verify Centos Alfresco') { steps { script {verify_image('alfresco.json')}}}
-               // stage('Verify Oracle Linux') { steps { script {verify_image('oraclelinux.json')}}}
+                stage('Verify Centos Alfresco') { steps { script {verify_image('alfresco.json')}}}
+                //stage('Verify Oracle Linux') { steps { script {verify_image('oraclelinux.json')}}}
             }
         }
 
         stage('Build Packer AMIS') {
             parallel {
-                //stage('Build Amazon Linux') { steps { script {build_image('amazonlinux.json')}}}
-                //stage('Build Amazon Linux 2') { steps { script {build_image('amazonlinux2.json')}}}
-                //stage('Build Amazon Linux 2 Jenkins Slave') { steps { script {build_image('jenkins_slave.json')}}}
+                stage('Build Amazon Linux') { steps { script {build_image('amazonlinux.json')}}}
+                stage('Build Amazon Linux 2') { steps { script {build_image('amazonlinux2.json')}}}
+                stage('Build Amazon Linux 2 Jenkins Slave') { steps { script {build_image('jenkins_slave.json')}}}
                 stage('Build Centos 7') { steps { script {build_image('centos7.json')}}}
                 //stage('Build Oracle Linux') { steps { script {build_image('oraclelinux.json')}}}
             }

--- a/alfresco.json
+++ b/alfresco.json
@@ -40,6 +40,10 @@
           "563502482979"
       ],
       "ami_name": "HMPPS Alfresco {{user `branch_name`}} {{timestamp}}",
+      "ssh_interface": "private_ip",
+      "vpc_id": "vpc-02321f288159e5d0e",
+      "subnet_id": "subnet-00982fba28419ac5f",
+
       "ami_block_device_mappings": [{
         "device_name": "/dev/xvdb",
         "encrypted": true,

--- a/amazonlinux.json
+++ b/amazonlinux.json
@@ -30,6 +30,9 @@
       },
       "instance_type": "t2.micro",
       "ami_regions": ["eu-west-2"],
+      "ssh_interface": "private_ip",
+      "vpc_id": "vpc-02321f288159e5d0e",
+      "subnet_id": "subnet-00982fba28419ac5f",
       "ssh_username": "ec2-user",
       "ami_groups": "all",
       "ami_name": "HMPPS Base Amazon Linux {{user `branch_name`}} {{timestamp}}"

--- a/amazonlinux2.json
+++ b/amazonlinux2.json
@@ -32,6 +32,9 @@
       "instance_type": "t2.micro",
       "ami_regions": ["eu-west-2"],
       "ssh_username": "ec2-user",
+      "ssh_interface": "private_ip",
+      "vpc_id": "vpc-02321f288159e5d0e",
+      "subnet_id": "subnet-00982fba28419ac5f",
       "ami_groups": "all",
       "ami_name": "HMPPS Base Amazon Linux 2 LTS {{user `branch_name`}} {{timestamp}}"
     }

--- a/centos7.json
+++ b/centos7.json
@@ -36,6 +36,7 @@
       "ami_regions": ["eu-west-2"],
       "ssh_username": "centos",
       "ami_groups": "all",
+      "ssh_interface": "private_ip",
       "ami_name": "HMPPS Base CentOS {{user `branch_name`}} {{timestamp}}"
     }
   ]

--- a/centos7.json
+++ b/centos7.json
@@ -37,6 +37,8 @@
       "ssh_username": "centos",
       "ami_groups": "all",
       "ssh_interface": "private_ip",
+      "vpc_id": "vpc-02321f288159e5d0e",
+      "subnet_id": "subnet-00982fba28419ac5f",
       "ami_name": "HMPPS Base CentOS {{user `branch_name`}} {{timestamp}}"
     }
   ]

--- a/jenkins_slave.json
+++ b/jenkins_slave.json
@@ -30,6 +30,9 @@
       },
       "instance_type": "t2.micro",
       "ami_regions": ["eu-west-2"],
+      "ssh_interface": "private_ip",
+      "vpc_id": "vpc-02321f288159e5d0e",
+      "subnet_id": "subnet-00982fba28419ac5f",
       "ssh_username": "ec2-user",
       "ami_name": "HMPPS Jenkins Slave Amazon Linux 2 LTS {{user `branch_name`}} {{timestamp}}"
     }

--- a/oraclelinux.json
+++ b/oraclelinux.json
@@ -36,6 +36,9 @@
       ],
       "ami_virtualization_type": "hvm",
       "ami_regions": ["eu-west-2"],
+      "ssh_interface": "private_ip",
+      "vpc_id": "vpc-02321f288159e5d0e",
+      "subnet_id": "subnet-00982fba28419ac5f",
       "ami_root_device": {
       	"source_device_name": "/dev/xvdf",
       	"device_name": "/dev/xvda",


### PR DESCRIPTION
This will stop the security alerts as we will no longer be building images and assigning them a public IP and allowing SSH from 0.0.0.0/0

Instead this puts the instances in the same subnet and VPC as the Jenkins slaves and uses the private IP for SSH with no public IP allocated.