### PR TITLE
Ensuring the temp security group only allows internal traffic.

### DIFF
--- a/alfresco.json
+++ b/alfresco.json
@@ -48,6 +48,7 @@
       "ssh_interface": "private_ip",
       "vpc_id": "vpc-02321f288159e5d0e",
       "subnet_id": "subnet-00982fba28419ac5f",
+      "temporary_security_group_source_cidr": "10.0.0.0/8",
 
       "ami_block_device_mappings": [{
         "device_name": "/dev/xvdb",

--- a/amazonlinux.json
+++ b/amazonlinux.json
@@ -33,6 +33,7 @@
       "ssh_interface": "private_ip",
       "vpc_id": "vpc-02321f288159e5d0e",
       "subnet_id": "subnet-00982fba28419ac5f",
+      "temporary_security_group_source_cidr": "10.0.0.0/8",
       "ssh_username": "ec2-user",
       "ami_groups": "all",
       "ami_name": "HMPPS Base Amazon Linux {{user `branch_name`}} {{timestamp}}"

--- a/amazonlinux2.json
+++ b/amazonlinux2.json
@@ -35,6 +35,7 @@
       "ssh_interface": "private_ip",
       "vpc_id": "vpc-02321f288159e5d0e",
       "subnet_id": "subnet-00982fba28419ac5f",
+      "temporary_security_group_source_cidr": "10.0.0.0/8",
       "ami_groups": "all",
       "ami_name": "HMPPS Base Amazon Linux 2 LTS {{user `branch_name`}} {{timestamp}}"
     }

--- a/centos7.json
+++ b/centos7.json
@@ -39,6 +39,7 @@
       "ssh_interface": "private_ip",
       "vpc_id": "vpc-02321f288159e5d0e",
       "subnet_id": "subnet-00982fba28419ac5f",
+      "temporary_security_group_source_cidr": "10.0.0.0/8",
       "ami_name": "HMPPS Base CentOS {{user `branch_name`}} {{timestamp}}"
     }
   ]

--- a/jenkins_slave.json
+++ b/jenkins_slave.json
@@ -33,6 +33,7 @@
       "ssh_interface": "private_ip",
       "vpc_id": "vpc-02321f288159e5d0e",
       "subnet_id": "subnet-00982fba28419ac5f",
+      "temporary_security_group_source_cidr": "10.0.0.0/8",
       "ssh_username": "ec2-user",
       "ami_name": "HMPPS Jenkins Slave Amazon Linux 2 LTS {{user `branch_name`}} {{timestamp}}"
     }

--- a/oraclelinux.json
+++ b/oraclelinux.json
@@ -39,6 +39,7 @@
       "ssh_interface": "private_ip",
       "vpc_id": "vpc-02321f288159e5d0e",
       "subnet_id": "subnet-00982fba28419ac5f",
+      "temporary_security_group_source_cidr": "10.0.0.0/8",
       "ami_root_device": {
       	"source_device_name": "/dev/xvdf",
       	"device_name": "/dev/xvda",


### PR DESCRIPTION
The builds were happening without an external IP so all traffic had to
internal but the temporary security group that Packer creates was still
allowing 0.0.0.0/0 in which was triggering our security alerts.

Limiting this temporary security group to 10.0.0.0/8 will allow future
subnet changes while ensuring we don't trigger the security rules.